### PR TITLE
Fix the scaling issue for decimals > 2.

### DIFF
--- a/countUp.js
+++ b/countUp.js
@@ -13,7 +13,9 @@ function countUp(target, endVal, decimals, duration) {
     
     var self = this;
     this.d = document.getElementById(target);
-    this.dec = decimals * 10 || 0;
+
+    decimals = Math.max(0, decimals || 0);
+    this.dec = Math.pow(10, decimals);
     this.duration = duration * 1000 || 2000;
 
     this.startTime = null;


### PR DESCRIPTION
The issue is most visible for large `decimals`, say, 6. It should scale by 10^6 instead of 60 :)
