### PR TITLE
Exact easing

### DIFF
--- a/countUp.js
+++ b/countUp.js
@@ -21,7 +21,7 @@ function countUp(target, endVal, decimals, duration) {
     
     // Robert Penner's easeOutExpo
     this.easeOutExpo = function(t, b, c, d) {
-        return c * (-Math.pow(2, -10 * t / d) + 1) + b;
+        return c * (-Math.pow(2, -10 * t / d) + 1) * 1024 / 1023 + b;
     }
     this.stepUp = function(timestamp) {
         


### PR DESCRIPTION
This PR fixes `easeOutExpo` so that when `target == duration` it returns the exact value of `endVal`. The current version returns `endVal * 1023 / 1024`, which makes the number "jumps" to the end value when `endVal` is sufficiently large.
