### PR TITLE
Allow target to accept something other than an ID

### DIFF
--- a/countUp.js
+++ b/countUp.js
@@ -45,7 +45,7 @@ function countUp(target, startVal, endVal, decimals, duration) {
     // toggle easing
     this.useEasing = true;
     
-    this.d = document.getElementById(target);
+    this.d = (typeof target === 'string') ? document.getElementById(target) : target;
     self.startVal = Number(startVal);
     endVal = Number(endVal);
     this.countDown = (startVal > endVal) ? true : false;


### PR DESCRIPTION
Was working with this and found myself wanting to use something other than an ID, when I already had some elements referenced. I kept the ability to pass a string if you wish to continue to use the ID as well.
