### PR TITLE
fix resume reset conflict and safe resume() call

### DIFF
--- a/countUp.js
+++ b/countUp.js
@@ -54,6 +54,7 @@ function countUp(target, startVal, endVal, decimals, duration, options) {
 
     this.d = (typeof target === 'string') ? document.getElementById(target) : target;
     this.startVal = Number(startVal);
+    this.originStartVal = Number(startVal);
     this.endVal = Number(endVal);
     this.countDown = (this.startVal > this.endVal) ? true : false;
     this.startTime = null;
@@ -134,13 +135,17 @@ function countUp(target, startVal, endVal, decimals, duration, options) {
     this.reset = function() {
         self.startTime = null;
         cancelAnimationFrame(self.rAF);
+        self.startVal = self.originStartVal;
+        self.frameVal = self.originStartVal;
         self.d.innerHTML = self.formatNumber(self.startVal.toFixed(self.decimals));
     }
     this.resume = function() {
-        self.startTime = null;
-        self.duration = self.remaining;
-        self.startVal = self.frameVal;
-        requestAnimationFrame(self.count);
+        if (self.remaining && self.frameVal != self.originStartVal){
+            self.startTime = null;
+            self.duration = self.remaining;
+            self.startVal = self.frameVal;
+            requestAnimationFrame(self.count);   
+        }
     }
     this.formatNumber = function(nStr) {
         nStr += '';


### PR DESCRIPTION
current version have one bug:
use

start -> stop -> resume -> reset 

now reset() not origin start value, it show stop value when reset() ,it is error...

if call resume() before start() will have some bug.
