### PR TITLE
Add support for prefix and suffix text

### DIFF
--- a/countUp.coffee
+++ b/countUp.coffee
@@ -1,5 +1,5 @@
 ###
-# 
+#
 # countUp.js
 # by @inorganik
 # v 1.1.2
@@ -20,11 +20,13 @@
 countUp = (target, startVal, endVal, decimals, duration, options) ->
 
   # default options
-  @options = options || { 
+  @options = options || {
     useEasing: true # toggle easing
     useGrouping: true # 1,000,000 vs 1000000
     separator: ',' # character to use as a separator
     decimal: '.' # character to use as a decimal
+    prefix: null # text that will be prepended at the start
+    suffix: null # text that will be appended at the end
   }
   if @options.separator == '' then @options.useGrouping = false;
 
@@ -36,7 +38,7 @@ countUp = (target, startVal, endVal, decimals, duration, options) ->
   ]
 
   @doc = if (typeof target == 'string') then document.getElementById target else target
-  @startVal = Number @startVal  
+  @startVal = Number @startVal
   @endVal = Number @endVal
   @countDown = if (@startVal > @endVal) then true else false
   @startTime = null
@@ -83,7 +85,7 @@ countUp = (target, startVal, endVal, decimals, duration, options) ->
     @timestamp = timestamp
 
     progress = timestamp - @startTime
-      
+
     # to ease or not to ease is the question
     if @options.useEasing
       if @countDown
@@ -97,11 +99,11 @@ countUp = (target, startVal, endVal, decimals, duration, options) ->
         @frameVal = @startVal - i
       else
         @frameVal = @startVal + (@endVal - @startVal) * (progress / @duration)
-        
+
     # decimal
     @frameVal = Math.round(@frameVal * @dec) / @dec
 
-    # don't go past enVal since progress can exceed duration in last grame   
+    # don't go past enVal since progress can exceed duration in last grame
     if @countDown
       @frameVal = if (@framVal < @endVal) then @endVal else @frameVal
     else
@@ -151,7 +153,13 @@ countUp = (target, startVal, endVal, decimals, duration, options) ->
       while rgx.test(x1)
         x1 = x1.replace(rgx, '$1' + @options.separator + '$2')
 
-    x1 + x2
+    output = x1 + x2
+
+    if @options.prefix
+      output = @options.prefix + output
+    if @options.suffix
+      output += @options.suffox
+    output
 
   # format @startVal on initialization
   @doc.innerHTML = @formatNumber @startVal.toFixed(decimals)

--- a/countUp.js
+++ b/countUp.js
@@ -3,7 +3,7 @@
     countUp.js
     by @inorganik
     v 1.1.2
-    
+
 */
 
 // target = id of html element or var of previously selected html element where counting occurs
@@ -46,7 +46,9 @@ function countUp(target, startVal, endVal, decimals, duration, options) {
         useEasing : true, // toggle easing
         useGrouping : true, // 1,000,000 vs 1000000
         separator : ',', // character to use as a separator
-        decimal : '.' // character to use as a decimal
+        decimal : '.', // character to use as a decimal
+        prefix: null, // text that will be prepended at the start
+        suffix: null // text that will be appended at the end
     }
     if (this.options.separator == '') this.options.useGrouping = false;
 
@@ -66,20 +68,20 @@ function countUp(target, startVal, endVal, decimals, duration, options) {
     this.duration = duration * 1000 || 2000;
 
     this.version = function () { return '1.1.2' }
-    
+
     // Robert Penner's easeOutExpo
     this.easeOutExpo = function(t, b, c, d) {
         return c * (-Math.pow(2, -10 * t / d) + 1) * 1024 / 1023 + b;
     }
     this.count = function(timestamp) {
-        
+
         if (self.startTime === null) self.startTime = timestamp;
 
         self.timestamp = timestamp;
 
         var progress = timestamp - self.startTime;
         self.remaining = self.duration - progress;
-        
+
         // to ease or not to ease
         if (self.options.useEasing) {
             if (self.countDown) {
@@ -96,27 +98,27 @@ function countUp(target, startVal, endVal, decimals, duration, options) {
                 self.frameVal = self.startVal + (self.endVal - self.startVal) * (progress / self.duration);
             }
         }
-        
+
         // decimal
         self.frameVal = Math.round(self.frameVal*self.dec)/self.dec;
-        
+
         // don't go past endVal since progress can exceed duration in the last frame
         if (self.countDown) {
             self.frameVal = (self.frameVal < self.endVal) ? self.endVal : self.frameVal;
         } else {
             self.frameVal = (self.frameVal > self.endVal) ? self.endVal : self.frameVal;
         }
-        
+
         // format and print value
         self.d.innerHTML = self.formatNumber(self.frameVal.toFixed(self.decimals));
-               
+
         // whether to continue
         if (progress < self.duration) {
             self.rAF = requestAnimationFrame(self.count);
         } else {
             if (self.callback != null) self.callback();
         }
-    }  
+    }
     this.start = function(callback) {
         self.callback = callback;
         // make sure values are valid
@@ -155,7 +157,15 @@ function countUp(target, startVal, endVal, decimals, duration, options) {
                 x1 = x1.replace(rgx, '$1' + self.options.separator + '$2');
             }
         }
-        return x1 + x2;
+
+        var output = x1 + x2;
+        if (self.options.prefix) {
+            output = self.options.prefix + output;
+        }
+        if (self.options.suffix) {
+            output += self.options.suffix;
+        }
+        return output;
     }
 
     // format startVal on initialization

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 
     <meta charset="UTF-8">
-    <meta name="robots" content="index,follow"> 
+    <meta name="robots" content="index,follow">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 
@@ -13,7 +13,7 @@
 
     <script type="text/javascript" src="countUp.js"></script>
     <script type="text/javascript">
-    
+
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
@@ -80,6 +80,14 @@
                     <input type="text" value="." id="decimal" style="width:15px; padding:0 5px;" onkeyup="updateCodeVisualizer()">
                     <label class="inlineLabel">Decimal</label>
                 </div>
+                <div class="inlineLeft marginRight">
+                    <input type="text" value="" id="prefix" style="width:15px; padding:0 5px;" onkeyup="updateCodeVisualizer()">
+                    <label class="inlineLabel">Prefix</label>
+                </div>
+                <div class="inlineLeft marginRight">
+                    <input type="text" value="" id="suffix" style="width:15px; padding:0 5px;" onkeyup="updateCodeVisualizer()">
+                    <label class="inlineLabel">Suffix</label>
+                </div>
             </form>
         </section>
         <section>
@@ -122,7 +130,7 @@
     var useOnComplete = false;
     var useEasing = true;
     var useGrouping = true;
-    
+
     // create instance
     window.onload = function() {
         // fire animation
@@ -150,13 +158,17 @@
         var endVal = document.getElementById("endVal").value;
         endVal = Number(endVal.replace(',','').replace(' ',''));
         var decimals = document.getElementById("decimals").value;
-        var duration = document.getElementById("duration").value; 
+        var duration = document.getElementById("duration").value;
+        var prefix = document.getElementById("prefix").value;
+        var suffix = document.getElementById("suffix").value;
 
         options = {
             useEasing : useEasing,
             useGrouping : useGrouping,
             separator : document.getElementById("separator").value,
-            decimal : document.getElementById("decimal").value
+            decimal : document.getElementById("decimal").value,
+            prefix: prefix,
+            suffix: suffix
         }
 
         // you don't have to create a new instance of countUp every time you start an animation,
@@ -229,12 +241,17 @@
         var duration = document.getElementById("duration").value;
         var separator = document.getElementById("separator").value;
         var decimal = document.getElementById("decimal").value;
+        var prefix = document.getElementById("prefix").value;
+        var suffix = document.getElementById("suffix").value;
+
 
         var code = 'var options = {<br>';
         code += (useEasing) ? '&emsp;&emsp;useEasing : true, <br>' : '&emsp;&emsp;useEasing : false, <br>';
         code += (useGrouping) ? '&emsp;&emsp;useGrouping : true, <br>' : '&emsp;&emsp;useGrouping : false, <br>';
         code += '&emsp;&emsp;separator : \''+separator+'\', <br>';
         code += '&emsp;&emsp;decimal : \''+decimal+'\' <br>';
+        code += '&emsp;&emsp;prefix : \''+prefix+'\' <br>';
+        code += '&emsp;&emsp;suffix : \''+suffix+'\' <br>';
         code += '}<br>';
         code += 'var demo = new countUp("myTargetElement", '+startVal+', '+endVal+', '+decimals+', '+duration+', options);<br>';
         if (useOnComplete) {


### PR DESCRIPTION
I'm using this to animate the value of a SVG 'text' element in a d3 chart, and I needed a prefix and suffix option to display a '%' sign at the end, so I added those as options.

Updated the .js, .coffee, and the index.html files to add the functionality.
