### PR TITLE
Remove id attribute to make count-up directive can be used as a child directive

### DIFF
--- a/angular-countUp.js
+++ b/angular-countUp.js
@@ -26,7 +26,7 @@
 		        	- pauseResume() removed
 		        	- $filter used instead of formatNumber()
 		        */
-				function CountUp(target, startVal, endVal, decimals, duration) {
+				function CountUp(startVal, endVal, decimals, duration) {
 
 			        // make sure requestAnimationFrame and cancelAnimationFrame are defined
 			        // polyfill for browsers without native support
@@ -54,7 +54,7 @@
 			            }
 			        }
 
-			        this.d = document.getElementById(target);
+			        this.d = $el[0];
 			        this.startVal = startVal;
 			        this.endVal = endVal;
 			        this.countDown = (this.startVal > this.endVal);
@@ -152,10 +152,10 @@
 					dec = Number($attrs.decimals) || 0;
 
 				// construct countUp 
-				var countUp = new CountUp($attrs.id, sta, end, dec, dur);
+				var countUp = new CountUp(sta, end, dec, dur);
 				if (end > 9999) {
 					// make easing smoother for large numbers
-					countUp = new CountUp($attrs.id, sta, end - 100, dec, dur / 2);
+					countUp = new CountUp(sta, end - 100, dec, dur / 2);
 				}
 				
 				function animate() {


### PR DESCRIPTION
Having the id attribute blocks users to use the directive within another directive.

ex:
`<my-driective attr1="" attr2=""></my directive>`

In `<my-directive>`, the template use count-up like this
`<span count-up id="numberAnimation" end-val="123" duration="3"></span>`

Because `<my-driective>` is a reusable control but with the same id hard-code, count-up cannot work well.

In AngularJS directive link function, you already have the DOM element. There is no need to specify an id for the animation target.