### PR TITLE
Add a missing 'decimals' argument in one of the examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ numAnim.update(someValue);
 For large numbers, since CountUp has a long way to go in just a few seconds, the animation seems to abruptly stop. The solution is to subtract 100 from your `endVal`, then use the callback to invoke the `update` method which completes the animation with the same duration with a difference of only 100 to animate:
 ```js
 var endVal = 9645.72;
-var numAnim = new CountUp("targetElem", 0, endVal - 100, duration/2);
+var numAnim = new CountUp("targetElem", 0, endVal - 100, 2, duration/2);
 numAnim.start(function() {
 	numAnim.update(endVal);
 });


### PR DESCRIPTION
Following #165, updated the example to include a missing argument.