### PR TITLE
Increasing width of suffix and prefix inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,11 +89,11 @@
 					<label class="inlineLabel">Decimal</label>
 				</div>
 				<div class="inlineLeft marginRight">
-					<input type="text" value="" id="prefix" style="width:15px; padding:0 5px;" onkeyup="updateCodeVisualizer()">
+					<input type="text" value="" id="prefix" style="width:150px; padding:0 5px;" onkeyup="updateCodeVisualizer()">
 					<label class="inlineLabel">Prefix</label>
 				</div>
 				<div class="inlineLeft marginRight">
-					<input type="text" value="" id="suffix" style="width:15px; padding:0 5px;" onkeyup="updateCodeVisualizer()">
+					<input type="text" value="" id="suffix" style="width:150px; padding:0 5px;" onkeyup="updateCodeVisualizer()">
 					<label class="inlineLabel">Suffix</label>
 				</div>
 			</form>


### PR DESCRIPTION


## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Test your changes
- [x] Squashed commits
- [ ] Followed the build steps


## Description

_The original width of 15px seemed to narrow if a user wanted to add "years old" as a suffix.


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
