### PR TITLE
create umd module on build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7401,6 +7401,24 @@
         "inherits": "^2.0.1"
       }
     },
+    "rollup": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.6.1.tgz",
+      "integrity": "sha512-1RhFDRJeg027YjBO6+JxmVWkEZY0ASztHhoEUEWxOwkh4mjO58TFD6Uo7T7Y3FbmDpRTfKhM5NVxJyimCn0Elg==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.1.2"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+          "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
     "rsvp": {
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
 		"url": "git+https://github.com/inorganik/countUp.js.git"
 	},
 	"scripts": {
-		"build": "npm run clean && tsc && gulp",
+		"build": "npm run clean && tsc && gulp && npm run build:umd",
+		"build:umd": "rollup dist/countUp.js --format umd --file dist/countUp.umd.js --name countUp",
 		"clean": "gulp clean",
 		"lint": "tslint --project tsconfig.json",
 		"test": "jest",
@@ -27,6 +28,7 @@
 		"gulp-uglify": "^3.0.2",
 		"http-server": "^0.11.1",
 		"jest": "^24.9.0",
+		"rollup": "^2.6.1",
 		"ts-jest": "^24.0.0",
 		"tslint": "^5.12.1",
 		"typescript": "^3.3.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "lib": ["es2017", "dom"],
     "module": "esnext",
+    "moduleResolution": "node",
     "declaration": true,
     "outDir": "dist",
     "target": "es5",


### PR DESCRIPTION
with this you can access countup when added as a script tag in the browser like this:

```js
const countUp = new window.countUp.Countup('targetId', 5234, options);
```

which is not optimal but atleast its accessible 😅

I tried adding it as both named and default export but then you had to access it at `window.countup.default` instaed..

If we remove the named export and only have the default export it would be accessible at `window.CountUp` but I guess it was changed to named for some reason so I am fine with having it as it is in this PR :)