### PR TITLE
fix: make window check SSR safe

### DIFF
--- a/src/countUp.ts
+++ b/src/countUp.ts
@@ -88,7 +88,7 @@ export class CountUp {
     }
 
     // scroll spy
-    if (window !== undefined && this.options.enableScrollSpy) {
+    if (typeof window !== 'undefined' && this.options.enableScrollSpy) {
       if (!this.error) {
         // set up global array of onscroll functions
         window['onScrollFns'] = window['onScrollFns'] || [];


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Test your changes
- [x] Followed the build steps


## Description

When using countup on the server side (node.js), it will break with `ReferenceError: window is not defined`

I changed the check if global `window` exists to be SSR safe.

Related issue in upstream library for react: https://github.com/glennreyes/react-countup/issues/655

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
