### PR TITLE
fix: Correct "types" path in "exports" to "./dist/countUp.d.ts"

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"url": "git+https://github.com/inorganik/countUp.js.git"
 	},
 	"exports": {
+    "types": "./dist/countUp.d.ts",
 		"import": "./dist/countUp.min.js",
 		"require": "./dist/countUp.umd.js"
 	},


### PR DESCRIPTION
## I'm submitting a...
- [x] Bug Fix


## Checklist

- [x] Test your changes
- [x] Followed the build steps


## Description

I found that 2.8.1 modified export, which made other downstream applications unable to access type, causing a series of ts type errors. I hope you can help me take a look.

https://github.com/inorganik/countUp.js/compare/v2.8.0...v2.8.1

![image](https://github.com/user-attachments/assets/52d836f4-3a4b-4f78-9444-47fad236f777)



## Does this PR introduce a breaking change?

- [x] No

