### PR TITLE
Get Countup Number From Target Element

### DIFF
--- a/src/countUp.ts
+++ b/src/countUp.ts
@@ -338,6 +338,6 @@ export class CountUp {
     c * (-Math.pow(2, -10 * t / d) + 1) * 1024 / 1023 + b;
 
   removeSeparators(number: string): number {
-    return Number(number.split(',').join(''));
+    return parseFloat(number.replace(new RegExp(this.options.separator, 'g'), ''))
   }
 }

--- a/src/countUp.ts
+++ b/src/countUp.ts
@@ -66,7 +66,7 @@ export class CountUp {
 
   constructor(
     target: string | HTMLElement | HTMLInputElement,
-    private endVal: number,
+    private endVal?: number,
     public options?: CountUpOptions
   ) {
     this.options = {
@@ -78,6 +78,9 @@ export class CountUp {
     this.easingFn = (this.options.easingFn) ?
       this.options.easingFn : this.easeOutExpo;
 
+    this.el = (typeof target === 'string') ? document.getElementById(target) : target;
+    endVal = endVal == null ? this.removeSeparators(this.el.innerHTML) : endVal;
+
     this.startVal = this.validateValue(this.options.startVal);
     this.frameVal = this.startVal;
     this.endVal = this.validateValue(endVal);
@@ -88,7 +91,6 @@ export class CountUp {
     if (this.options.separator === '') {
       this.options.useGrouping = false;
     }
-    this.el = (typeof target === 'string') ? document.getElementById(target) : target;
     if (this.el) {
       this.printValue(this.startVal);
     } else {
@@ -335,4 +337,7 @@ export class CountUp {
   easeOutExpo = (t: number, b: number, c: number, d: number): number =>
     c * (-Math.pow(2, -10 * t / d) + 1) * 1024 / 1023 + b;
 
+  removeSeparators(number: string): number {
+    return Number(number.split(',').join(''));
+  }
 }


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[X] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [X] Test your changes
- [X] Followed the build steps


## Description

_please describe the changes that you are making_

Adding this feature request
https://github.com/inorganik/countUp.js/issues/301

_for features, please describe how to use the new feature_

This feature allows you not to have to set the `endVal` parameter when constructing the `CountUp()` object. This will allow it to default to reading the target element inner HTML as the `endVal`.

The target element innerHTML can be a generic number such as `2000` or it can have separators `2,000` and a new internal method will parse the innerHTML value to remove the separators and convert it to a number.

_please include a reference to an existing issue, if applicable_
https://github.com/inorganik/countUp.js/issues/301

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```
